### PR TITLE
Refactor: replace value with defaultValue in Editor component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@homehero/hero-style",
-  "version": "1.26.7",
+  "version": "1.26.8",
   "main": "dist/index.js",
   "browser": "dist/index.umd.js",
   "module": "dist/index.es.js",

--- a/src/components/molecule/editor/Editor.js
+++ b/src/components/molecule/editor/Editor.js
@@ -17,7 +17,7 @@ const Editor = ({ value, modules, fullHeight, onChange, toolbar, rows, className
       <ReactQuill
         modules={!toolbar ? { toolbar: null } : { toolbar: optionsToolbar }}
         theme="snow"
-        value={value}
+        defaultValue={value}
         onChange={onChange}
         {...otherProps}
       />


### PR DESCRIPTION
### Mudanças
- troca props `value` por `defaultValue` no componente `Editor` pra aceitar manipulação do texto via regex sem perder o foco